### PR TITLE
Anarcho-Communism의 번역명을 아나코 공산주의로 수정

### DIFF
--- a/ideologies.js
+++ b/ideologies.js
@@ -1,6 +1,6 @@
 ideologies = [
     {
-        "name": "아나코 코뮤니즘",
+        "name": "아나코 공산주의",
         "stats": {
             "econ": 100,
             "dipl": 50,


### PR DESCRIPTION
https://ko.wikipedia.org/wiki/아나르코공산주의
사실 별 차이 없긴 하지만 아무래도 (코뮤니즘보다는) 이게 좀 더 맞는것 같기도 하고요...
아나코 vs 아나르코는 구글 검색결과가 더 많은 아나코 쪽으로 했어요